### PR TITLE
ODP:2480: Update cruise-control and kafka-connect libraries to be compatible with JDK-1.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2978,12 +2978,12 @@ project(':connect:runtime') {
 
     testRuntimeOnly libs.slf4jlog4j
     testRuntimeOnly libs.bcpkix
-    implementation 'org.mongodb.kafka:mongo-kafka:1.13.0:all@jar'
+    implementation 'org.mongodb.kafka:mongo-kafka:1.6.1:all@jar'
     implementation 'com.google.cloud:pubsub-group-kafka-connector:1.2.0@jar'
-    implementation 'io.aiven:aiven-kafka-connect-s3:2.15.0@jar'
-    implementation 'io.aiven:aiven-kafka-connect-jdbc:6.10.0@jar'
+    implementation 'io.aiven:aiven-kafka-connect-s3:2.6.0@jar'
+    implementation 'io.aiven:aiven-kafka-connect-jdbc:6.1.2@jar'
     implementation 'com.amazonaws:amazon-kinesis-kafka-connecter:0.0.8@jar'
-    implementation 'com.linkedin.cruisecontrol:cruise-control-metrics-reporter:2.5.137@jar'
+    implementation 'com.linkedin.cruisecontrol:cruise-control-metrics-reporter:2.5.137-8@jar'
   }
 
   javadoc {

--- a/build.gradle
+++ b/build.gradle
@@ -2978,10 +2978,10 @@ project(':connect:runtime') {
 
     testRuntimeOnly libs.slf4jlog4j
     testRuntimeOnly libs.bcpkix
-    implementation 'org.mongodb.kafka:mongo-kafka:1.6.1:all@jar'
+    implementation 'org.mongodb.kafka:mongo-kafka:1.6.1-8:all@jar'
     implementation 'com.google.cloud:pubsub-group-kafka-connector:1.2.0@jar'
-    implementation 'io.aiven:aiven-kafka-connect-s3:2.6.0@jar'
-    implementation 'io.aiven:aiven-kafka-connect-jdbc:6.1.2@jar'
+    implementation 'io.aiven:aiven-kafka-connect-s3:2.6.0-8@jar'
+    implementation 'io.aiven:aiven-kafka-connect-jdbc:6.1.2-8@jar'
     implementation 'com.amazonaws:amazon-kinesis-kafka-connecter:0.0.8@jar'
     implementation 'com.linkedin.cruisecontrol:cruise-control-metrics-reporter:2.5.137-8@jar'
   }


### PR DESCRIPTION
This patch was tested locally.