### PR TITLE
ODP-2770: Refactor Kafka3 to use ambari-python-wrap for all scripts

### DIFF
--- a/docker/common.py
+++ b/docker/common.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!#!/usr/bin/env ambari-python-wrap
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/docker/docker_build_test.py
+++ b/docker/docker_build_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!#!/usr/bin/env ambari-python-wrap
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/docker/docker_release.py
+++ b/docker/docker_release.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!#!/usr/bin/env ambari-python-wrap
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/docker/test/__init__.py
+++ b/docker/test/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!#!/usr/bin/env ambari-python-wrap
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/docker/test/docker_sanity_test.py
+++ b/docker/test/docker_sanity_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!#!/usr/bin/env ambari-python-wrap
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/kafka-merge-pr.py
+++ b/kafka-merge-pr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!#!/usr/bin/env ambari-python-wrap
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more

--- a/release.py
+++ b/release.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!#!/usr/bin/env ambari-python-wrap
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more

--- a/release_notes.py
+++ b/release_notes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!#!/usr/bin/env ambari-python-wrap
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/reviewers.py
+++ b/reviewers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!#!/usr/bin/env ambari-python-wrap
 # -*- coding: utf-8 -*-
 
 #

--- a/tests/bin/external_trogdor_command_example.py
+++ b/tests/bin/external_trogdor_command_example.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!#!/usr/bin/env ambari-python-wrap
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.


### PR DESCRIPTION
ODP-2770: Refactor Kafka3 to use ambari-python-wrap for all scripts

Tested in RHEL9,8 Ubuntu20 and 22 Env's