### PR TITLE
OSV-7524|OSV-5705 - CVE - Upgrade mongo-kafka to 2.0.0 which will increase jackson and avro versions to fix CVEs CVE-2020-36518 and CVE-2024-47561

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2978,7 +2978,7 @@ project(':connect:runtime') {
 
     testRuntimeOnly libs.slf4jlog4j
     testRuntimeOnly libs.bcpkix
-    implementation 'org.mongodb.kafka:mongo-kafka:1.13.0:all@jar'
+    implementation 'org.mongodb.kafka:mongo-kafka:2.0.0:all@jar'
     implementation 'com.google.cloud:pubsub-group-kafka-connector:1.2.0@jar'
     implementation 'io.aiven:aiven-kafka-connect-s3:2.15.0@jar'
     implementation 'io.aiven:aiven-kafka-connect-jdbc:6.10.0@jar'


### PR DESCRIPTION
Upgrade mongo-kafka to 2.0.0 which will increase jackson and avro versions to fix CVEs CVE-2020-36518 and CVE-2024-47561