### PR TITLE
OSV-5706 - CVE - Upgrade netty to 4.1.127.Final to fix CVEs CVE-2025-24970

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -146,7 +146,7 @@ versions += [
   lz4: "1.8.0",
   mavenArtifact: "3.8.8",
   metrics: "2.2.0",
-  netty: "4.1.115.Final",
+  netty: "4.1.127.Final",
   opentelemetryProto: "1.0.0-alpha",
   protobuf: "3.25.5", // a dependency of opentelemetryProto
   pcollections: "4.0.1",


### PR DESCRIPTION
Upgrade netty to 4.1.127.Final to fix CVEs CVE-2025-24970