### PR TITLE
ODP-6274 : Update Kafka connectors to internal ODP stack version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2981,11 +2981,11 @@ project(':connect:runtime') {
 
     testRuntimeOnly libs.slf4jlog4j
     testRuntimeOnly libs.bcpkix
-    implementation 'org.mongodb.kafka:mongo-kafka:1.6.1-8:all@jar'
-    implementation 'com.google.cloud:pubsub-group-kafka-connector:1.2.0@jar'
+    implementation 'org.mongodb.kafka:mongo-kafka:1.6.1.3.2.3.6-2:all@jar'
+    implementation 'com.google.cloud:pubsub-group-kafka-connector:1.2.0.3.2.3.6-2@jar'
     implementation 'io.aiven:aiven-kafka-connect-s3:2.6.0-8@jar'
     implementation 'io.aiven:aiven-kafka-connect-jdbc:6.1.2-8@jar'
-    implementation 'com.amazonaws:amazon-kinesis-kafka-connecter:0.0.8@jar'
+    implementation 'com.amazonaws:amazon-kinesis-kafka-connecter:0.0.8.3.2.3.6-2@jar'
     implementation 'com.linkedin.cruisecontrol:cruise-control-metrics-reporter:2.5.137-8@jar'    
   }
 


### PR DESCRIPTION
This patch was tested locally.